### PR TITLE
fix #114: remove linebreaks from brand declaration

### DIFF
--- a/djaoapp/templates/_navbarbrand.html
+++ b/djaoapp/templates/_navbarbrand.html
@@ -1,6 +1,4 @@
 <a class="navbar-brand" href="{{request|url_home}}">
     <img class="d-inline-block" src="{{'/static/img/logo-djaodjin-128.png'|djasset}}" />
-    <span class="d-none d-sm-inline-block" data-trnc data-trnc-len="7">
-        {{request|site_printable_name}}
-    </span>
+    <span class="d-none d-sm-inline-block" data-trnc data-trnc-len="7">{{request|site_printable_name}}</span>
 </a>


### PR DESCRIPTION
line breaks between the brand name and surrounding tags caused more characters to be counted than needed. 