### PR TITLE
Quick fix for #147

### DIFF
--- a/djaoapp/templates/accounts/login.html
+++ b/djaoapp/templates/accounts/login.html
@@ -1,7 +1,7 @@
 {% extends "accounts/base.html" %}
 
 {% block content %}
-<div class="container pt-4 pb-4">
+<div class="container pt-4 pb-5 mb-3">
     <div class="offset-sm-2 col-sm-8">
         <div class="page-header my-4">
             <h1 class="text-center">

--- a/djaoapp/templates/accounts/login.html
+++ b/djaoapp/templates/accounts/login.html
@@ -1,7 +1,7 @@
 {% extends "accounts/base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container pt-4 pb-4">
     <div class="offset-sm-2 col-sm-8">
         <div class="page-header my-4">
             <h1 class="text-center">

--- a/djaoapp/templates/accounts/recover.html
+++ b/djaoapp/templates/accounts/recover.html
@@ -1,7 +1,7 @@
 {% extends "accounts/base.html" %}
 
 {% block accounts_content %}
-<div class="container pt-4">
+<div class="container pt-4 pb-5 mb-3">
     <div class="row">
         <div class="offset-sm-2 col-sm-8">
             <div class="page-header my-4">
@@ -10,7 +10,7 @@
                 </h1>
             </div>
             <p class="text-center">
-                {% trans %}Enter your e-mail address to reset your password.{% endtrans %}
+                {% trans %}Enter your email address to reset your password.{% endtrans %}
             </p>
 
             <div class="offset-sm-2 col-sm-8">

--- a/djaoapp/templates/accounts/recover.html
+++ b/djaoapp/templates/accounts/recover.html
@@ -1,7 +1,7 @@
 {% extends "accounts/base.html" %}
 
 {% block accounts_content %}
-<div class="container">
+<div class="container pt-4">
     <div class="row">
         <div class="offset-sm-2 col-sm-8">
             <div class="page-header my-4">
@@ -10,7 +10,7 @@
                 </h1>
             </div>
             <p class="text-center">
-                {% trans %}Enter your e-mail address to reset and create a new password.{% endtrans %}
+                {% trans %}Enter your e-mail address to reset your password.{% endtrans %}
             </p>
 
             <div class="offset-sm-2 col-sm-8">

--- a/djaoapp/templates/accounts/register.html
+++ b/djaoapp/templates/accounts/register.html
@@ -1,7 +1,7 @@
 {% extends "accounts/base.html" %}
 
 {% block content %}
-    <div class="container mb-5">
+    <div class="container d-flex pt-4 pb-5 mb-3">
         <div class="offset-sm-2 col-sm-8">
             <div class="page-header my-4">
                 <h1 class="text-center">

--- a/djaoapp/templates/accounts/register.html
+++ b/djaoapp/templates/accounts/register.html
@@ -1,7 +1,7 @@
 {% extends "accounts/base.html" %}
 
 {% block content %}
-    <div class="container d-flex pt-4 pb-5 mb-3">
+    <div class="container pt-4 pb-5 mb-3">
         <div class="offset-sm-2 col-sm-8">
             <div class="page-header my-4">
                 <h1 class="text-center">


### PR DESCRIPTION
Story: 

I made some attempts at vertical centering the login elements on the page. Once I was able to finally get it to work properly, I realized that my changes ended up breaking all the rest of the pages that _weren't_ login pages for the site... It wasn't pretty. : /

Ultimately, I am including a quick fix for this issue now, that artificially creates spacing between the elements to avoid them from being cut off.

Note: fixing vertical centering properly (and not breaking other pages) may take future reworking of app architecture.

![screencapture-localhost-8000-login-2019-10-29-17_53_41](https://user-images.githubusercontent.com/7801775/67820432-63440d80-fa76-11e9-92b4-36e40d381b57.png)

