### PR TITLE
Hot-fix for broken Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ FROM python:3.9-slim-bullseye
 #     Loads the list of native packages
 RUN apt-get update -y
 #     Installs required native packages
-RUN DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install python3-psycopg2 python3-cryptography python3-coverage python3-setproctitle python3-lxml python3-pillow python3-cffi python3-billiard python3-ldap python3-cairo libpangoft2-1.0-0
+RUN DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install python3-psycopg2 python3-cryptography python3-coverage python3-setproctitle python3-lxml python3-pil python3-cffi python3-billiard python3-ldap python3-cairo libpangoft2-1.0-0
 
-RUN /usr/local/bin/python3 -m venv /app --system-site-packages
-RUN /app/bin/pip install pip setuptools --upgrade
+RUN /usr/local/bin/python3 -m venv --upgrade-deps --system-site-packages /app
 
 # Bundle app source
 COPY . /app/reps/djaoapp


### PR DESCRIPTION
Use `python3-pil` Debian package instead of `python3-pillow` package.
Debian changed the name of the package in their repository, but it is
still built from the `Pillow` PyPi project.

Use `venv --upgrade-deps` instead of `pip install --upgrade setuptools`.
Starting with Python version 3.9, `venv` supports automatically
installing the latest versions of `pip` and `setuptools` by using the
`--upgrade-deps` flag; see
[https://github.com/python/cpython/issues/78737]() for details. `pip`
seems to have trouble deleting currently installed versions of
`setuptools` as of late, making it impossible to upgrade and thereby
breaking the build.