### PR TITLE
(Docker) Migrate PyPI packages from Dpkg to Wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,59 @@
+# syntax=docker/dockerfile:1
 FROM python:3.9-slim-bullseye
-# As of 2021-10-04: Python 3.9.7, Debian 11.0 (Bullseye)
-# RUN which python3
-# RUN python3 --version
-# RUN cat /etc/debian_version
 
-#     Loads the list of native packages
-RUN apt-get update -y
-#     Installs required native packages
-RUN DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install python3-psycopg2 python3-cryptography python3-coverage python3-setproctitle python3-lxml python3-pil python3-cffi python3-billiard python3-ldap python3-cairo libpangoft2-1.0-0
+# Install required external libraries for wheels: lxml, python-ldap,
+# pycairo, WeasyPrint.
+RUN set -eux; \
+      apt-get update; \
+      apt-get -y install --no-install-recommends \
+        libxslt1.1 \
+        libldap-2.4-2 libldap-common \
+        libcairo2 \
+        libpangoft2-1.0-0; \
+      rm -rf /var/lib/apt/lists/*;
 
-RUN /usr/local/bin/python3 -m venv --upgrade-deps --system-site-packages /app
+# Set up virtual environment
+ENV VIRTUAL_ENV="/app"
+RUN python -m venv --upgrade-deps $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin${PATH:+:}$PATH"
 
 # Bundle app source
-COPY . /app/reps/djaoapp
-WORKDIR /app/reps/djaoapp
-RUN /app/bin/pip install -r requirements.txt
+COPY . $VIRTUAL_ENV/reps/djaoapp
+WORKDIR $VIRTUAL_ENV/reps/djaoapp
+
+# Install source-wheel build-time dependencies, build and/or install all
+# wheels, then uninstall source-wheel build-time dependencies.
+RUN set -eux; \
+      \
+      savedAptMark="$(apt-mark showmanual)"; \
+      \
+      apt-get update; \
+      apt-get -y install --no-install-recommends \
+        libxslt1-dev \
+        libldap2-dev libsasl2-dev build-essential\
+        libcairo2-dev pkg-config; \
+      \
+      pip install -r requirements.txt; \
+      \
+      apt-mark auto '.*'; \
+      apt-mark manual $savedAptMark; \
+      apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+      rm -rf /var/lib/apt/lists/*;
 
 # Create local configuration files
-RUN /bin/mkdir -p /etc/djaoapp
-RUN /bin/sed -e "s,\%(SECRET_KEY)s,`/app/bin/python -c 'import sys ; from random import choice ; sys.stdout.write("".join([choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^*-_=+") for i in range(50)]))'`," etc/credentials > /etc/djaoapp/credentials
-RUN /bin/sed -e "s,^DB_LOCATION *= *\".*\",DB_LOCATION = \"sqlite3:///app/reps/djaoapp/db.sqlite\"," etc/site.conf > /etc/djaoapp/site.conf
-RUN /bin/sed -e 's,%(APP_NAME)s,djaoapp,g' -e 's,%(LOCALSTATEDIR)s,/var,g'\
+RUN mkdir -p /etc/djaoapp
+RUN sed -e "s,\%(SECRET_KEY)s,`python -c 'import sys ; from random import choice ; sys.stdout.write("".join([choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^*-_=+") for i in range(50)]))'`," etc/credentials > /etc/djaoapp/credentials
+RUN sed -e "s,^DB_LOCATION *= *\".*\",DB_LOCATION = \"sqlite3:///app/reps/djaoapp/db.sqlite\"," etc/site.conf > /etc/djaoapp/site.conf
+RUN sed -e 's,%(APP_NAME)s,djaoapp,g' -e 's,%(LOCALSTATEDIR)s,/var,g'\
   -e 's,%(PID_FILE)s,/var/run/djaoapp.pid,g'\
   -e 's,bind="127.0.0.1:%(APP_PORT)s",bind="0.0.0.0:80",'\
   etc/gunicorn.conf > /etc/djaoapp/gunicorn.conf
 
+# Print version info for build log
+RUN echo "Built with" `python --version` '('`which python`')' "on Debian" `cat /etc/debian_version` '(Bullseye Slim).';
+
 # Expose application http port
-Expose 80
+EXPOSE 80/tcp
 
 # Run
-CMD ["/app/bin/gunicorn", "-c", "/etc/djaoapp/gunicorn.conf", "djaoapp.wsgi"]
+ENTRYPOINT ["/app/bin/gunicorn", "-c", "/etc/djaoapp/gunicorn.conf", "djaoapp.wsgi"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,16 @@ social-auth-app-django==4.0.0 # v1.2.0 does not support Django>=2.1
 whitenoise==5.1.0
 # >=53 requires Pango1.44, AMZLinux2 has 1.42, but on Debian (Dockerfile), if we
 # use version 52.5, it leads to `OSError: cannot load library 'pangocairo-1.0'`
-WeasyPrint==53.3
+WeasyPrint==53.3 # Depends on libpangoft2 (Debian) and Pillow (wheel)
+
+# Wheels previously installed as site-packages
+psycopg2-binary==2.9.3 # Binary wheel.
+setproctitle==1.2.3 # Binary wheel.
+coverage==6.3.2 # Python wheel.
+billiard==4.0.0 # Python wheel
+python-ldap==3.4.0 # Source wheel. Depends on libldap2.4-2 (Debian).
+pycairo==1.21.0 # Source wheel. Depends on libcairo2 (Debian).
+#lxml # Source wheel. Depends on libxml2, libxslt1.1 (Debian). Built as a dependency of another wheel.
 
 # To run with DEBUG=1
 django-extensions==2.2.9


### PR DESCRIPTION
Migrate Python packages within Djaoapp Docker image from Debian _dpkg_
packages, managed by _apt_, to PyPI _wheels_, managed by _pip_, to
improve reproducibility and consistency of dependency resolution and
run-time environment.

  Debian's Python packages depend on, and are installed to, the
  `site-packages` of Debian's build of Python from Debian's
  repositories.  Debian's version of Python is maintained and versioned
  separately from the version of Python that is built and packaged in
  the official Python Docker image(s), upon which Djaoapp's Docker image
  is based, thus presenting a high possibility of breakage in the
  future. The addition of the Debian build of Python to the Djaoapp
  Docker image introduces the potential for Python operations to be
  executed in the wrong Python environment, and adds unnecessary and/or
  redundant packages to the image. Versioning and naming of packages
  within Debian's repositories is not stable, and therefore, minimizing
  direct dependence on such packages is desirable.

  This commit introduces a significant departure from the previously
  established dependency graphs, build-time environments, and run-time
  environments of many of the libraries required by Djaoapp.  Testing of
  relevant functionality is advised.

Update `requirements.txt` with migrated wheels and additional
documentation in comments. Pinned versions of new wheels are based on
the latest available wheels at the time of this commit. Some adjustment
to pinned version numbers may be required if the current versions cause
errors.

Replace
[python3-psycopg2](https://packages.debian.org/bullseye/python3-psycopg2)
Debian package with
[psycopg2-binary](https://pypi.org/project/psycopg2/) binary wheel. See
[https://www.psycopg.org/psycopg3/docs/basic/install.html#binary-installation]()
for more details on how third-party libraries are incorporated into the
binary wheel.

Replace
[python3-cryptography](https://packages.debian.org/bullseye/python3-cryptography)
Debian package with
[cryptography](https://pypi.org/project/cryptography/) binary wheel.
_Cryptography_ is required by other packages in `requirements.txt` and
will be installed automatically by pip.

Replace
[python3-coverage](https://packages.debian.org/bullseye/python3-coverage)
Debian package with [coverage](https://pypi.org/project/coverage/)
Python wheel.

Replace
[python3-setproctitle](https://packages.debian.org/bullseye/python3-setproctitle)
Debian package with
[setproctitle](https://pypi.org/project/setproctitle/) binary wheel.

Replace
[python3-lxml](https://packages.debian.org/bullseye/python3-lxml) Debian
package with [lxml](https://pypi.org/project/lxml/) source wheel.
_Lxml_ is a dependency of another package in `requirements.txt` and will
be installed automatically by pip.  _Lxml_ depends on
[libxml2](https://packages.debian.org/bullseye/libxml2) and
[libxslt1.1](https://packages.debian.org/bullseye/libxslt1.1) at
run-time. Only _libxslt1.1_ is explicitly installed in the Dockerfile,
as _apt_ will automatically install _libxml2_ as a dependency of
_libxslt1.1_.  Building _lxml_ requires header files from
[libxml2-dev](https://packages.debian.org/bullseye/libxml2-dev) and
[libxslt1-dev](https://packages.debian.org/bullseye/libxslt1-dev).
Installing _libxslt1-dev_ implicitly installs _libxml2-dev_. See
[https://lxml.de/installation.html]() for more details on building
_lxml_.

Replace [python3-pil](https://packages.debian.org/bullseye/python3-pil)
Debian package with [Pillow](https://pypi.org/project/Pillow/) binary
wheel.  Prior to this commit, invoking `pip install -r requirements.txt`
would automatically install _Pillow_ as a dependency of _WeasyPrint_.
Consequently, _python3-pil_ was likely redundant, and this change should
not impact functionality.  The _Pillow_ binary wheel comes pre-packaged
with most of its third-party dependencies, but there are some
exceptions; see
[https://pillow.readthedocs.io/en/latest/installation.html]() for more
details.

Replace
[python3-cffi](https://packages.debian.org/bullseye/python3-cffi) Debian
package with [cffi](https://pypi.org/project/cffi/) binary wheel.
_Cffi_ is a dependency of many other packages in `requirements.txt` and
will be automatically installed by pip.

Replace
[python3-billard](https://packages.debian.org/bullseye/python3-billiard)
Debian package with [billiard](https://pypi.org/project/billiard/)
Python wheel.

Replace
[python3-ldap](https://packages.debian.org/bullseye/python3-ldap) Debian
package with [python-ldap](https://pypi.org/project/python-ldap/) source
wheel. _Python-ldap_ depends on
[libldap-2.4-2](https://packages.debian.org/bullseye/libldap-2.4-2) and
[libsasl2-2](https://packages.debian.org/bullseye/libsasl2-2) at
run-time. The optional
[libldap-common](https://packages.debian.org/bullseye/libldap-common)
package is marked as "recommended" by _libldap-2.4-2_ in _apt_'s package
database.  Since automatic installation of recommended packages by _apt_
is now disabled (see below), _libldap-common_ is now installed
explicitly, for good measure.  Building _python-ldap_ requires
[libldap2-dev](https://packages.debian.org/bullseye/libldap2-dev),
[libsasl2-dev](https://packages.debian.org/bullseye/libsasl2-dev), and
the GNU compilation and build tool-chains. The required GNU tools are
provided by the
[build-essential](https://packages.debian.org/bullseye/build-essential)
package. See
[https://www.python-ldap.org/en/python-ldap-3.4.0/installing.html#installing-from-pypi]()
for more details on building _python-ldap_.

Replace
[python3-cairo](https://packages.debian.org/bullseye/python3-cairo)
Debian package with [pycairo](https://pypi.org/project/pycairo/) source
wheel.  _Pycairo_ depends on
[libcairo2](https://packages.debian.org/bullseye/libcairo2) at run-time.
Building _pycairo_ requires
[libcairo2-dev](https://packages.debian.org/bullseye/libcairo2-dev) and
[pkg-config](https://packages.debian.org/bullseye/pkg-config); see
[https://pycairo.readthedocs.io/en/latest/getting_started.html]() for
more details.

Disable automatic installation of packages marked "recommended", by
_apt_.

  With the addition of the `--no-install-recommends` flag to `apt-get
  install` commands, _apt_ will no longer implicitly install packages
  marked as "recommended" by other packages. This may cause issues at
  run-time for features that have an undocumented dependency on a
  _recommended_ package. A list of _recommended_ packages, along with
  other dpkg metadata, can be generated by running `apt-mark showmanual
  | xargs apt-cache depends` inside the running Docker container.

Add cleanup routines to the end of the _wheel_ build / install step:

  Debian packages installed solely to satisfy build-time dependencies
  are marked as "automatically installed" by `apt-mark`, and are
  subsequently purged from the image.  Debian packages installed to
  satisfy run-time dependencies are marked as "manually installed" by
  `apt-mark`, and are left intact. All local caches of package databases
  and package tarballs are deleted at the end of the build step.

Remove absolute paths of executable binaries from most `RUN` commands to
avoid potential future portability issues with
["UsrMerge"](https://wiki.debian.org/UsrMerge); see also,
[https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/]().
Additionally, with the removal of Debian Python packages, `python` will
always resolve to either `/usr/local/bin/python` (default) or
`${VIRTUAL_ENV}/bin/python` (if $VIRTUAL_ENV is set and prepended to
$PATH).

Add echo of Python and Debian versions to Docker build log / output to
assist in auditing dependency graphs and resolving errors.