### PR TITLE
Compilemessages bugfix & updated docs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ build-assets: $(ASSETS_DIR)/cache/base.css \
 	$(installFiles) $(ASSETS_DIR)/cache/djaodjin-vue.js $(ASSETS_DIR)/cache/djaodjin-vue$(APP_VERSION_SUFFIX).js
 	$(installFiles) $(ASSETS_DIR)/cache/saas.js $(ASSETS_DIR)/cache/saas$(APP_VERSION_SUFFIX).js
 	$(installFiles) $(ASSETS_DIR)/cache/theme-editors.js $(ASSETS_DIR)/cache/theme-editors$(APP_VERSION_SUFFIX).js
-	cd $(srcDir) && $(MANAGE) compilemessages
+	cd $(srcDir) && $(MANAGE) compilemessages --ignore='$(subst $(abspath $(srcDir))/,,$(installTop))/lib'
 	cd $(srcDir) && DEBUG=0 $(MANAGE) collectstatic --noinput
 	cd $(srcDir) && $(ESCHECK) $(ASSETS_DIR)/cache/*.js $(ASSETS_DIR)/vendor/*.js
 
@@ -395,7 +395,7 @@ $(srcDir)/djaoapp/locale/fr/LC_MESSAGES/django.mo: \
 				$(wildcard $(srcDir)/djaoapp/locale/es/LC_MESSAGES/*.po) \
 				$(wildcard $(srcDir)/djaoapp/locale/fr/LC_MESSAGES/*.po) \
 				$(wildcard $(srcDir)/djaoapp/locale/pt/LC_MESSAGES/*.po)
-	cd $(srcDir) && $(MANAGE) compilemessages
+	cd $(srcDir) && $(MANAGE) compilemessages --ignore='$(subst $(abspath $(srcDir))/,,$(installTop))/lib'
 
 
 require-pip:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you are looking to add features, this project integrates
 
 Tested with
 
-- **Python:** 3.10, **Django:** 4.2 ([LTS](https://www.djangoproject.com/download/))
+- **Python:** 3.14, **Django:** 5.2 ([LTS](https://www.djangoproject.com/download/))
 
 Install
 -------
@@ -45,11 +45,11 @@ the active directory to that source directory.
 
 The following commands are executed at the top of source directory.
 
-Please first verify that you have at least Python3.10 and make installed on your
+Please first verify that you have at least Python3.14 and make installed on your
 development environment
 
     $ python --version
-    Python 3.10.19
+    Python 3.14.5
     $ make --version
     GNU Make 3.81
 


### PR DESCRIPTION
When I tried to re-create the local djaoapp setup using the latest djaoapp version (that is based on Django 5.2), I got an error during pip install that sphinx dependency expects Python >= 3.12. So I assume Python was upgraded, I tried pip install with Python 3.14 and it worked. However, now `make build-assets` was failing when `manage.py compilemessages` was invoked (due to faulty po files in sphinx dependency). I fixed this by excluding *.po files from venv site-packages - these packages already come with compiled *.mo files, so there's no need to re-compile them. I have run test suite against djaoapp running on Python 3.14 and it passed. The `compilemessage --ignore` doesn't accept absolute paths, that's why the weird makefile command. Let me know if I'm doing something wrong. Here's the log:

```
➜  djaoapp git:(main) ✗ python3.10 -m venv .venv
➜  djaoapp git:(main) ✗ source .venv/bin/activate
(.venv) ➜  djaoapp git:(main) ✗ pip install -r requirements-native.txt
...
Collecting pyYAML==6.0.1 (from -r requirements.txt (line 67))
  Using cached PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl.metadata (2.1 kB)
ERROR: Ignored the following versions that require a different python version: 6.0 Requires-Python >=3.12; 6.0.1 Requires-Python >=3.12; 6.0.2 Requires-Python >=3.12; 6.0.3 Requires-Python >=3.12; 6.0.4 Requires-Python >=3.12; 6.0.5 Requires-Python >=3.12; 6.0a1 Requires-Python >=3.12; 6.0b1 Requires-Python >=3.12; 6.0rc1 Requires-Python >=3.12; 6.1a1 Requires-Python >=3.12; 8.2.0 Requires-Python >=3.11; 8.2.0rc1 Requires-Python >=3.11; 8.2.0rc2 Requires-Python >=3.11; 8.2.1 Requires-Python >=3.11; 8.2.2 Requires-Python >=3.11; 8.2.3 Requires-Python >=3.11; 8.3.0 Requires-Python >=3.11; 9.0.0 Requires-Python >=3.11; 9.0.0rc1 Requires-Python >=3.11; 9.0.0rc2 Requires-Python >=3.11; 9.0.0rc3 Requires-Python >=3.11; 9.0.0rc4 Requires-Python >=3.11; 9.0.1 Requires-Python >=3.11; 9.0.2 Requires-Python >=3.11; 9.0.3 Requires-Python >=3.11; 9.0.4 Requires-Python >=3.11; 9.1.0 Requires-Python >=3.12; 9.1.0rc1 Requires-Python >=3.12; 9.1.0rc2 Requires-Python >=3.12
ERROR: Could not find a version that satisfies the requirement Sphinx==9.1.0 (from versions: 0.1.61611, 0.1.61798, 0.1.61843, 0.1.61945, 0.1.61950, 0.2, 0.3, 0.4, 0.4.1, 0.4.2, 0.4.3, 0.5, 0.5.1, 0.5.2b1, 0.5.2, 0.6b1, 0.6, 0.6.1, 0.6.2, 0.6.3, 0.6.4, 0.6.5, 0.6.6, 0.6.7, 1.0b1, 1.0b2, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.1, 1.1.1, 1.1.2, 1.1.3, 1.2b1, 1.2b2, 1.2b3, 1.2, 1.2.1, 1.2.2, 1.2.3, 1.3b1, 1.3b2, 1.3b3, 1.3, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.6, 1.4a1, 1.4b1, 1.4, 1.4.1, 1.4.2, 1.4.3, 1.4.4, 1.4.5, 1.4.6, 1.4.7, 1.4.8, 1.4.9, 1.5a1, 1.5a2, 1.5b1, 1.5, 1.5.1, 1.5.2, 1.5.3, 1.5.4, 1.5.5, 1.5.6, 1.6b1, 1.6b2, 1.6b3, 1.6.1, 1.6.2, 1.6.3, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.7.0b1, 1.7.0b2, 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.7.7, 1.7.8, 1.7.9, 1.8.0b1, 1.8.0, 1.8.1, 1.8.2, 1.8.3, 1.8.4, 1.8.5, 1.8.6, 2.0.0b1, 2.0.0b2, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 3.0.0b1, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.4.1, 3.4.2, 3.4.3, 3.5.0, 3.5.1, 3.5.2, 3.5.3, 3.5.4, 4.0.0b1, 4.0.0b2, 4.0.0, 4.0.1, 4.0.2, 4.0.3, 4.1.0, 4.1.1, 4.1.2, 4.2.0, 4.3.0, 4.3.1, 4.3.2, 4.4.0, 4.5.0, 5.0.0b1, 5.0.0, 5.0.1, 5.0.2, 5.1.0, 5.1.1, 5.2.0, 5.2.0.post0, 5.2.1, 5.2.2, 5.2.3, 5.3.0, 6.0.0b1, 6.0.0b2, 6.0.0, 6.0.1, 6.1.0, 6.1.1, 6.1.2, 6.1.3, 6.2.0, 6.2.1, 7.0.0rc1, 7.0.0, 7.0.1, 7.1.0, 7.1.1, 7.1.2, 7.2.0, 7.2.1, 7.2.2, 7.2.3, 7.2.4, 7.2.5, 7.2.6, 7.3.0, 7.3.1, 7.3.2, 7.3.3, 7.3.4, 7.3.5, 7.3.6, 7.3.7, 7.4.0, 7.4.1, 7.4.2, 7.4.3, 7.4.4, 7.4.5, 7.4.6, 7.4.7, 8.0.0rc1, 8.0.0, 8.0.1, 8.0.2, 8.1.0, 8.1.1, 8.1.2, 8.1.3)

[notice] A new release of pip is available: 26.0.1 -> 26.1.1
[notice] To update, run: pip install --upgrade pip
ERROR: No matching distribution found for Sphinx==9.1.0
➜  djaoapp git:(main) ✗ rm -rf .venv
➜  djaoapp git:(main) ✗ python3.12 -m venv .venv
➜  djaoapp git:(main) ✗ source .venv/bin/activate
(.venv) ➜  djaoapp git:(main) ✗ pip install -r requirements-native.txt
Successfully installed billiard-4.2.0 cairocffi-1.3.0 coverage-6.3.2 cryptography-46.0.6 psycopg2-binary-2.9.12 pyOpenSSL-26.0.0 pyasn1-0.6.3 pyasn1_modules-0.4.2 pycairo-1.21.0 python-ldap-3.4.5 setproctitle-1.2.3
(.venv) ➜  djaoapp git:(main) ✗ pip install -r requirements.txt
...
(.venv) ➜  djaoapp git:(main) ✗ make vendor-assets-prerequisites
...
(.venv) ➜  djaoapp git:(main) ✗ make install-conf
...
(.venv) ➜  djaoapp git:(main) ✗ make build-assets
...
cd . && DJAOAPP_SETTINGS_LOCATION=/Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/etc/djaoapp python manage.py compilemessages
config loaded from '/Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/etc/djaoapp/credentials'
config loaded from '/Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/etc/djaoapp/site.conf'
Use Jinja2 templates engine.
...
processing file sphinx.po in /Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/lib/python3.12/site-packages/sphinx/locale/hu/LC_MESSAGES
Execution of msgfmt failed: /Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/lib/python3.12/site-packages/sphinx/locale/el/LC_MESSAGES/sphinx.po:591: 'msgstr' is not a valid Python brace format string, unlike 'msgid'. Reason: In the directive number 0, there is an unterminated format directive.
/Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/lib/python3.12/site-packages/sphinx/locale/el/LC_MESSAGES/sphinx.po:598: a format specification for argument 'current.__name__' doesn't exist in 'msgstr'
msgfmt: found 2 fatal errors
Execution of msgfmt failed: /Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/lib/python3.12/site-packages/sphinx/locale/fa/LC_MESSAGES/sphinx.po:599: a format specification for argument 'default.__name__' doesn't exist in 'msgstr'
msgfmt: found 1 fatal error
processing file sphinx.po in /Users/knivets/Projects/Work/djaodjin/djaoapp/.venv/lib/python3.12/site-packages/sphinx_rtd_theme/locale/it/LC_MESSAGES
...
CommandError: compilemessages generated one or more errors.
make: *** [build-assets] Error 1
```