### PR TITLE
CSP policy configuration

### DIFF
--- a/djaoapp/forms/custom_signup.py
+++ b/djaoapp/forms/custom_signup.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django_recaptcha.fields import ReCaptchaField
-from django_recaptcha.widgets import ReCaptchaV2Checkbox
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import PasswordResetForm
@@ -21,6 +20,7 @@ from signup.forms import (
     PasswordResetConfirmForm as PasswordResetConfirmFormBase,
     PasswordConfirmMixin, AuthenticationForm)
 
+from .widgets import CSPReCaptchaV2Checkbox
 from ..compat import gettext_lazy as _, reverse, six
 from ..utils import get_registration_captcha_keys
 
@@ -103,6 +103,7 @@ class ActivationForm(MissingFieldsMixin, PostalFormMixin, ActivationFormBase):
         widget=forms.widgets.Select(choices=countries), label=_("Country"))
 
     def __init__(self, *args, **kwargs):
+        csp_nonce = kwargs.pop('csp_nonce', None)
         self.user = kwargs.pop('instance', None)
         force_required = kwargs.pop('force_required', False)
         initial = kwargs.get('initial')
@@ -123,7 +124,8 @@ class ActivationForm(MissingFieldsMixin, PostalFormMixin, ActivationFormBase):
             self.fields['captcha'] = ReCaptchaField(
                     public_key=captcha_keys['public_key'],
                     private_key=captcha_keys['private_key'],
-                    widget=ReCaptchaV2Checkbox(
+                    widget=CSPReCaptchaV2Checkbox(
+                        csp_nonce=csp_nonce,
                         attrs={
                             'data-theme': 'clean',
                             'data-size': 'compact',
@@ -260,6 +262,7 @@ class SignupForm(MissingFieldsMixin, PostalFormMixin, forms.Form):
         widget=forms.widgets.Select(choices=countries), label=_("Country"))
 
     def __init__(self, *args, **kwargs):
+        csp_nonce = kwargs.pop('csp_nonce', None)
         self.user = kwargs.pop('instance', None)
         force_required = kwargs.pop('force_required', False)
         super(SignupForm, self).__init__(*args, **kwargs)
@@ -273,7 +276,8 @@ class SignupForm(MissingFieldsMixin, PostalFormMixin, forms.Form):
             self.fields['captcha'] = ReCaptchaField(
                     public_key=captcha_keys['public_key'],
                     private_key=captcha_keys['private_key'],
-                    widget=ReCaptchaV2Checkbox(
+                    widget=CSPReCaptchaV2Checkbox(
+                        csp_nonce=csp_nonce,
                         attrs={
                             'data-theme': 'clean',
                             'data-size': 'compact',

--- a/djaoapp/forms/widgets.py
+++ b/djaoapp/forms/widgets.py
@@ -1,0 +1,15 @@
+from django_recaptcha.widgets import ReCaptchaV2Checkbox
+
+
+class CSPReCaptchaV2Checkbox(ReCaptchaV2Checkbox):
+
+    template_name = "django_recaptcha/csp_widget_v2_checkbox.html"
+
+    def __init__(self, csp_nonce=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.csp_nonce = csp_nonce
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['csp_nonce'] = str(self.csp_nonce) if self.csp_nonce else ''
+        return context

--- a/djaoapp/settings.py
+++ b/djaoapp/settings.py
@@ -7,6 +7,8 @@ import datetime, os.path, sys
 from django import VERSION as DJANGO_VERSION
 from django.contrib.messages import constants as messages
 
+from csp.constants import NONE, SELF, UNSAFE_EVAL, UNSAFE_INLINE, NONCE
+
 from deployutils.configs import load_config, update_settings
 
 from .compat import reverse_lazy, settings_lazy
@@ -48,6 +50,7 @@ MULTITIER_SITE_MODEL = None
 # ----------------------------------------
 ALLOWED_HOSTS = ('*',)
 
+UPGRADE_INSECURE_REQUESTS_IN_ASSETS = False
 RULES_ENC_KEY_OVERRIDE = None
 RULES_ENTRY_POINT_OVERRIDE = None
 REQUESTS_TIMEOUT = 120
@@ -266,6 +269,7 @@ INSTALLED_APPS = ENV_INSTALLED_APPS + (
     'django.contrib.staticfiles',
     'rest_framework',
     'django_recaptcha',
+    'csp',
     'deployutils.apps.django_deployutils',
     'signup',  # Because we want `djresources.js` picked up from here.
     'saas',
@@ -289,6 +293,7 @@ elif not DEBUG:
 
 MIDDLEWARE += (
     'django.middleware.common.CommonMiddleware',
+    'csp.middleware.CSPMiddleware',
     'multitier.middleware.SiteMiddleware',
     'multitier.middleware.SetRemoteAddrFromForwardedFor',
     'rules.middleware.RulesMiddleware',
@@ -1036,3 +1041,54 @@ NOTIFICATION_BACKENDS = (
 
 # Demo mode ...
 REUSABLE_PRODUCTS = ('livedemo',)
+
+
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [SELF],
+        "script-src": [
+            SELF, UNSAFE_EVAL, NONCE,
+            # Stripe
+            # https://docs.stripe.com/security/guide?csp=csp-js
+            "https://js.stripe.com",
+            "https://*.js.stripe.com",
+            "https://connect-js.stripe.com",
+            "https://maps.googleapis.com",
+        ],
+        "style-src": [SELF, UNSAFE_INLINE],
+        "img-src": [
+            SELF, "https:", "data:",
+            # Stripe
+            "https://*.stripe.com",
+        ],
+        "connect-src": [
+            SELF,
+            # Stripe
+            "https://api.stripe.com",
+            "https://maps.googleapis.com",
+            # reCAPTCHA
+            # https://developers.google.com/recaptcha/docs/faq#im-using-content-security-policy-csp-on-my-website.-how-can-i-configure-it-to-work-with-recaptcha
+            "https://www.google.com/recaptcha/",
+        ],
+        "frame-src": [
+            SELF,
+            # Stripe
+            "https://js.stripe.com",
+            "https://*.js.stripe.com",
+            "https://connect-js.stripe.com",
+            "https://hooks.stripe.com",
+            # reCAPTCHA
+            "https://www.google.com/recaptcha/",
+            "https://recaptcha.google.com/recaptcha/",
+        ],
+        "frame-ancestors": [SELF],
+        "form-action": [SELF],
+        "object-src": [NONE],
+        "base-uri": [SELF],
+        # ace.js editor
+        "worker-src": [SELF, "blob:"],
+    },
+}
+
+if UPGRADE_INSECURE_REQUESTS_IN_ASSETS:
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["upgrade-insecure-requests"] = True

--- a/djaoapp/templates/_password_strength_scripts.html
+++ b/djaoapp/templates/_password_strength_scripts.html
@@ -4,7 +4,7 @@
 {% else %}
 <script type="text/javascript" src="{{'/assets/cache/auth.js'|asset}}"></script>
 {% endif %}
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript" charset="utf-8" nonce="{{request.csp_nonce}}">
 jQuery(document).ready(function($) {
 
     $("[name='new_password']").passwordStrength({

--- a/djaoapp/templates/app_proxy_help.html
+++ b/djaoapp/templates/app_proxy_help.html
@@ -94,7 +94,7 @@
 <script type="text/javascript" src="{{'/assets/cache/pages.js'|asset}}"></script>
 {% endif %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 jQuery(document).ready(function($) {
 
     // uploads

--- a/djaoapp/templates/base.html
+++ b/djaoapp/templates/base.html
@@ -209,7 +209,7 @@
                   <div class="alert alert-dismissible fade" style="display:none;">
                     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                   </div>
-                  <script type="text/javascript">
+                  <script type="text/javascript" nonce="{{request.csp_nonce}}">
                     var _showErrorMessagesProviderNotified = "{% trans %}We have been notified and have started on fixing the error. We apologize for the inconvenience.{% endtrans %}";
                   </script>
                 </div>
@@ -292,7 +292,7 @@
   {% endif %}
 
 {% block _bodyscripts %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 const DJAOAPP_API_BASE_URL = "{{''|site_url}}"; // djaodjin-menubar.js
 
 function injectAnalyticsScripts() {
@@ -332,7 +332,7 @@ const PRIVACY_COOKIES_ENABLED = {
 {% else %}
 <script type="text/javascript" src="{{'/assets/cache/base.js'|asset}}"></script>
 {% endif %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 function onLoadBase() {
   if( typeof djApi !== 'undefined' ) {
     djApi.apiBase = "{{''|site_url}}"; // djaodjin-saas et al.

--- a/djaoapp/templates/captcha/widget.html
+++ b/djaoapp/templates/captcha/widget.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
     var DjangoRecaptchaOptions = {{options}};
     if (typeof RecaptchaOptions !== 'object') {
         RecaptchaOptions = DjangoRecaptchaOptions;

--- a/djaoapp/templates/captcha/widget_ajax.html
+++ b/djaoapp/templates/captcha/widget_ajax.html
@@ -1,5 +1,5 @@
 <div id="Recap"></div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
   var RecaptchaOptions = {{options}};
   Recaptcha.create("{{public_key}}",
     "Recap",

--- a/djaoapp/templates/django_recaptcha/csp_widget_v2_checkbox.html
+++ b/djaoapp/templates/django_recaptcha/csp_widget_v2_checkbox.html
@@ -1,0 +1,5 @@
+{% include "django_recaptcha/includes/csp_js_v2_checkbox.html" %}
+<div
+    {% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}
+>
+</div>

--- a/djaoapp/templates/django_recaptcha/includes/csp_js_v2_checkbox.html
+++ b/djaoapp/templates/django_recaptcha/includes/csp_js_v2_checkbox.html
@@ -1,0 +1,8 @@
+{# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+<script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}" nonce="{{ csp_nonce }}"></script>
+<script type="text/javascript" nonce="{{ csp_nonce }}">
+    // Submit function to be called, after reCAPTCHA was successful.
+    var onSubmit_{{ widget_uuid }} = function(token) {
+        console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'")
+    };
+</script>

--- a/djaoapp/templates/extended_templates/_body_bottom.html
+++ b/djaoapp/templates/extended_templates/_body_bottom.html
@@ -21,7 +21,7 @@
 {% endif %}
 
 {# templates and PageElement editors #}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 {% if templates %}
 templateNames = {{templates|safe}};
 {% endif %}

--- a/djaoapp/templates/extended_templates/_edit_tools.html
+++ b/djaoapp/templates/extended_templates/_edit_tools.html
@@ -230,7 +230,7 @@
 <script type="text/javascript" src="{{'/assets/cache/theme-editors.js'|asset}}"></script>
 {% endif %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 jQuery(document).ready(function($) {
 
     // media gallery

--- a/djaoapp/templates/extended_templates/theme.html
+++ b/djaoapp/templates/extended_templates/theme.html
@@ -157,7 +157,7 @@
 {% else %}
 <script type="text/javascript" src="{{'/assets/cache/theme-editors.js'|asset}}"></script>
 {% endif %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 jQuery(document).ready(function($) {
 
     {% if urls.api_themes %}

--- a/djaoapp/templates/jinja2/debug_toolbar/redirect.html
+++ b/djaoapp/templates/jinja2/debug_toolbar/redirect.html
@@ -8,7 +8,7 @@
 <p class="notice">
 	The Django Debug Toolbar has intercepted a redirect to the above URL for debug viewing purposes. You can click the above link to continue with the redirect as normal.
 </p>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
     document.getElementById('redirect_to').focus();
 </script>
 </body>

--- a/djaoapp/templates/notification/detail.html
+++ b/djaoapp/templates/notification/detail.html
@@ -60,7 +60,7 @@
 <script type="text/javascript" src="{{'/assets/cache/theme-editors.js'|asset}}"></script>
 {% endif %}
 {% endif %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 jQuery(document).ready(function($) {
     var $el = $("#email-tpl-iframe");
 

--- a/djaoapp/templates/rules/app_dashboard.html
+++ b/djaoapp/templates/rules/app_dashboard.html
@@ -328,7 +328,7 @@
 
 
 {% block dashboard_bodyscripts %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 function getCSRFToken() {
             var vm = this;
             // Look first for an input node in the HTML page, i.e.

--- a/djaoapp/templates/saas/base.html
+++ b/djaoapp/templates/saas/base.html
@@ -73,7 +73,7 @@
 <script type="text/javascript" src="{{'/assets/vendor/nv.d3.js'|asset}}"></script>
 <script type="text/javascript" src="{{'/assets/vendor/trip.js'|asset}}"></script>
 <script type="text/javascript" src="{{'/assets/js/djaoapp-i18n.js'|asset}}"></script>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 Vue.prototype.$itemsPerPage =
     {% if items_per_page %}{{items_per_page}}{% else %}25{% endif %};
 //Vue.prototype.$sortDirection = ;
@@ -123,7 +123,7 @@ humanizeTimeDelta.$labels = {
 {% else %}
 <script type="text/javascript" charset="utf-8" src="{{'/assets/cache/djaodjin-vue.js'|asset}}"></script>
 {% endif %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 function onSaaSLoadBase() {
   Vue.use(Croppa);
   {% if FEATURES_REVERT_TO_VUE2 %}

--- a/djaoapp/templates/saas/billing/cart.html
+++ b/djaoapp/templates/saas/billing/cart.html
@@ -115,7 +115,7 @@
 {% else %}
 <script type="text/javascript" src="{{'/assets/cache/saas.js'|asset}}"></script>
 {% endif %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
     jQuery(document).ready(function($) {
         $(".collapsible").click(function(event) {
             var self = this;

--- a/djaoapp/templates/saas/billing/receipt.html
+++ b/djaoapp/templates/saas/billing/receipt.html
@@ -148,7 +148,7 @@
 {% else %}
 <script type="text/javascript" src="{{'/assets/cache/saas.js'|asset}}"></script>
 {% endif %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 jQuery(document).ready(function($) {
 
     $("#email-charge-receipt").chargeEmailReceipt({

--- a/djaoapp/templates/saas/metrics/base.html
+++ b/djaoapp/templates/saas/metrics/base.html
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block dashboard_bodyscripts %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 Vue.prototype.$tables = [{
     "key": "cash",
     "title": "Amounts",

--- a/djaoapp/templates/saas/profile/index.html
+++ b/djaoapp/templates/saas/profile/index.html
@@ -375,7 +375,7 @@
 
 {% block dashboard_bodyscripts %}
 {% if urls.user %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 Vue.directive('init-croppa', {
 inserted: function(el) {
     var croppaInstance = el.__vue__;

--- a/djaoapp/templates/saas/profile/subscribers.html
+++ b/djaoapp/templates/saas/profile/subscribers.html
@@ -389,7 +389,7 @@
 {% endblock %}
 
 {% block saas_bodyscripts %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 Vue.prototype.$sortDirection = "asc";
 Vue.prototype.$sortByField = "profile";
 </script>

--- a/djaoapp/views/contact.py
+++ b/djaoapp/views/contact.py
@@ -6,7 +6,6 @@ import logging, re, socket
 from smtplib import SMTPException
 
 from django_recaptcha.fields import ReCaptchaField
-from django_recaptcha.widgets import ReCaptchaV2Checkbox
 from deployutils.apps.django_deployutils.compat import is_authenticated
 from django import forms, http
 from django.core.exceptions import ValidationError, PermissionDenied
@@ -21,6 +20,7 @@ from saas.models import Organization
 from signup.auth import validate_redirect
 
 from ..compat import gettext_lazy as _, reverse, six
+from ..forms.widgets import CSPReCaptchaV2Checkbox
 from ..signals import user_contact
 from ..utils import get_contact_captcha_keys
 from ..validators import validate_contact_form
@@ -67,6 +67,7 @@ class ContactForm(forms.Form):
             'class':'form-control', 'placeholder': ""}))
 
     def __init__(self, *args, **kwargs):
+        csp_nonce = kwargs.pop('csp_nonce', None)
         super(ContactForm, self).__init__(*args, **kwargs)
         if not kwargs.get('initial', {}).get('email', None):
             captcha_keys = get_contact_captcha_keys()
@@ -74,7 +75,8 @@ class ContactForm(forms.Form):
                 self.fields['captcha'] = ReCaptchaField(
                     public_key=captcha_keys['public_key'],
                     private_key=captcha_keys['private_key'],
-                    widget=ReCaptchaV2Checkbox(
+                    widget=CSPReCaptchaV2Checkbox(
+                        csp_nonce=csp_nonce,
                         attrs={
                             'data-theme': 'clean',
                             'data-size': 'compact',
@@ -102,6 +104,11 @@ class ContactView(ProviderMixin, FormView):
         except serializers.ValidationError:
             raise PermissionDenied()
         return super(ContactView, self).dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super(ContactView, self).get_form_kwargs()
+        kwargs['csp_nonce'] = self.request.csp_nonce
+        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super(ContactView, self).get_context_data(**kwargs)

--- a/djaoapp/views/custom_signup.py
+++ b/djaoapp/views/custom_signup.py
@@ -61,6 +61,7 @@ class AuthMixin(AuthBaseMixin):
                     "data": data,
                     "files": self.request.FILES,
                 })
+        kwargs['csp_nonce'] = self.request.csp_nonce
         return kwargs
 
 

--- a/djaoapp/views/custom_signup.py
+++ b/djaoapp/views/custom_signup.py
@@ -64,6 +64,13 @@ class AuthMixin(AuthBaseMixin):
         kwargs['csp_nonce'] = self.request.csp_nonce
         return kwargs
 
+    def get_form(self, form_class=None):
+        if form_class is None:
+            form_class = self.get_form_class()
+        kwargs = self.get_form_kwargs()
+        if not issubclass(form_class, (ActivationForm, SignupForm)):
+            kwargs.pop('csp_nonce', None)
+        return form_class(**kwargs)
 
     def get_landing(self):
         register_path = super(AuthMixin, self).get_landing()

--- a/etc/site.conf
+++ b/etc/site.conf
@@ -94,3 +94,5 @@ AWS_ACCOUNT_ID = ''
 
 # Path to compiler to CSS assets
 SASSC_BIN = "%(binDir)s/sassc"
+
+UPGRADE_INSECURE_REQUESTS_IN_ASSETS = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ djangorestframework==3.16.1       # 3.16 requires Python>=3.9
 # We need a version of django-fernet-fields that supports Django4.2
 django-fernet-fields @ git+https://github.com/djaodjin/django-fernet-fields.git@6f261ed465a7fbafa1c41b635f7acd9fd6f3ccca
 # next 8 usually installed through source repo directly.
+django-csp==4.0
 djaodjin-deployutils==0.14.5
 djaodjin-extended-templates==0.5.2
 djaodjin-multitier==0.3.1


### PR DESCRIPTION
This PR implements a CSP policy.

I dropped `unsafe-inline` for `script-src` but kept for `style-src`. Dropping it for `style-src` would require replacing dynamic Vue `:style` attrs which is tricky in some instances (e.g `<i class="fa-solid fa-circle align-middle" :style="'color: ' + colorFn(index)"></i>`). Leaving it for `style-src` will also have minimal impact on security (as opposed to `script-src`). Finally, I added `upgrade-insecure-requests` directive (disabled by default, but ideally it should be enabled on prod) which will ensure that all static assets are served using HTTPS.

I also had to override django_recaptcha to ensure it's CSP compliant, which is a known issue: https://github.com/django-recaptcha/django-recaptcha/issues/101